### PR TITLE
[JOLINT-82] reusable accordion component

### DIFF
--- a/app/(info-page)/faq/page.tsx
+++ b/app/(info-page)/faq/page.tsx
@@ -1,6 +1,6 @@
 const Faq = () => {
   return (
-    <section className='min-h-[calc(100vh-5rem)] md:pt-28 pt-20 md:min-h-[calc(100vh-7rem)]'>
+    <section className='min-h-[calc(100vh-5rem)] pt-20 md:min-h-[calc(100vh-7rem)] md:pt-28'>
       <div className='orange-gradient absolute inset-0 -z-10' />
       <h1 className='font-heading text-3xl font-bold md:text-5xl'>FAQ</h1>
       <p className='pt-6 text-lg md:pt-6 md:text-2xl'>

--- a/components/Accordion.tsx
+++ b/components/Accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import * as AccordionPrimitive from '@radix-ui/react-accordion'
+import { ChevronDown } from 'lucide-react'
+
+type AccordionProps = {
+  trigger: React.ReactNode
+  content: React.ReactNode
+  icon?: boolean
+  className?: string
+}
+
+const Accordion = ({ trigger, content, icon, className }: AccordionProps) => {
+  return (
+    <AccordionPrimitive.Root type='single' collapsible>
+      <AccordionPrimitive.Item value='accordion' className={className}>
+        <AccordionPrimitive.Trigger asChild className='group cursor-pointer'>
+          <div className='flex justify-between gap-4'>
+            {trigger}
+            {icon && (
+              <ChevronDown className='group-data-[state=open]:rotate-180' />
+            )}
+          </div>
+        </AccordionPrimitive.Trigger>
+        <AccordionPrimitive.Content asChild>
+          {content}
+        </AccordionPrimitive.Content>
+      </AccordionPrimitive.Item>
+    </AccordionPrimitive.Root>
+  )
+}
+
+export default Accordion


### PR DESCRIPTION
highly reusable accordion component
- takes JSX as trigger and content, meaning you can send in text or images or something else
- has a chevron icon that can be activated
- completely unstyled to fit the (at the moment) three different places we're going to use this component

example usage:
```
<Accordion
  className='flex flex-col gap-4 rounded-2xl border-2 border-blue-dull p-8'
  trigger={
    <h4 className='text-2xl font-bold'>
      Title here
    </h4>
  }
  content={<p className='text-xl'>Content text here</p>}
  icon
/>
```